### PR TITLE
Fixing NumPy bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 streamlit
 tensorflow-cpu==2.3.0
 Pillow==7.2.0
-numpy
+numpy==1.18.5


### PR DESCRIPTION
Changed the NumPy version to 1.18.5 which is compatible with TensorFlow 2.3.0 